### PR TITLE
fix: remove unnecessary import

### DIFF
--- a/analysisTool.ts
+++ b/analysisTool.ts
@@ -14,7 +14,6 @@
  */
 
 import * as fs from 'fs';
-import { resolve } from 'dns';
 const nodesloc = require('node-sloc');
 const gitignore = require('parse-gitignore');
 const glob = require('glob');


### PR DESCRIPTION
Seems like you imported { resolve } from 'dns' by mistake