### PR TITLE
fix: Hybrid apps being reported as already migrated

### DIFF
--- a/analysisTool.ts
+++ b/analysisTool.ts
@@ -240,7 +240,9 @@ export class AnalysisTool {
         if (filename.substr(-12) === 'package.json' || filename.substr(-10) === 'bower.json') {
             if (fileData.match(/\"\@angular\/core\"\:/) || fileData.match(/\"angular2\"\:/)) {
                 this.analysisDetails.usingAngular = true;
-            } else if (fileData.match(/\"angular\"\:/)) {
+            }
+
+            if (fileData.match(/\"angular\"\:/)) {
                 this.analysisDetails.usingAngularJS = true;
             }
         } else if (fileData.match(/https\:\/\/ajax\.googleapis\.com\/ajax\/libs\/angularjs/)) {


### PR DESCRIPTION
Hybrid apps where the `package.json` file contains both `angular` and `@angular/..` are being reported as already migrated.