### PR TITLE
fix(analysisTool): verify path is a file

### DIFF
--- a/analysisTool.ts
+++ b/analysisTool.ts
@@ -167,7 +167,9 @@ export class AnalysisTool {
 
         for (let fileOrFolder of this.buildPathIgnoringGlobs(rootpath)) {
             currentPath = rootpath + "/" + fileOrFolder;
-            this.testFile(currentPath);
+            if (fs.lstatSync(currentPath).isFile()) {
+                this.testFile(currentPath)
+            }
         }
     }
 

--- a/analysisTool.ts
+++ b/analysisTool.ts
@@ -168,7 +168,7 @@ export class AnalysisTool {
         for (let fileOrFolder of this.buildPathIgnoringGlobs(rootpath)) {
             currentPath = rootpath + "/" + fileOrFolder;
             if (fs.lstatSync(currentPath).isFile()) {
-                this.testFile(currentPath)
+                this.testFile(currentPath);
             }
         }
     }


### PR DESCRIPTION
Before testing a file for "patterns", verify that it is a file and not a directory.
Checking the suffix is not enough, because some directories have names with ".js" in the end (e.g. blob.js) which are mistaken to be files.