### PR TITLE
No longer report component matches as needing to be modified

### DIFF
--- a/analysisTool.ts
+++ b/analysisTool.ts
@@ -265,7 +265,6 @@ export class AnalysisTool {
         }
         if (fileData.match(/\.component\(/) || fileData.match(/component\(/)) {
             this.analysisDetails.componentCount++;
-            this.pushValueOnKey(this.analysisDetails.mapOfFilesToConvert, filename, " AngularJS component");
         }
     }
 


### PR DESCRIPTION
fix(analysisTool) Fix for #7. No longer push component matches to the mapOfFilesToConvert. Component is the desired target, so listing these among the files needed to be modified doesn't make sense.