### PR TITLE
Support files with multiple controllers / components + AngularJS @Component()

### DIFF
--- a/analysisTool.ts
+++ b/analysisTool.ts
@@ -267,13 +267,20 @@ export class AnalysisTool {
     checkFileForComponent(filename: string, fileData: string) {
         const controllerMatches = fileData.match(/\.controller\(/g);
         const componentMatches = fileData.match(/component\(/g);
+        const decoratedComponentMatches = fileData.match(/@Component\(/g);
 
         if (controllerMatches) {
             this.analysisDetails.controllersCount += controllerMatches.length;
             this.pushValueOnKey(this.analysisDetails.mapOfFilesToConvert, filename, " controller");
         }
+
         if (componentMatches) {
             this.analysisDetails.componentCount += componentMatches.length;
+        }
+
+        // AngularJS decorated component matches
+        if (decoratedComponentMatches && !fileData.includes('@angular/core')) {
+            this.analysisDetails.componentCount += decoratedComponentMatches.length;
         }
     }
 

--- a/analysisTool.ts
+++ b/analysisTool.ts
@@ -265,12 +265,15 @@ export class AnalysisTool {
     }
 
     checkFileForComponent(filename: string, fileData: string) {
-        if (fileData.match(/\.controller\(/)) {
-            this.analysisDetails.controllersCount++;
+        const controllerMatches = fileData.match(/\.controller\(/g);
+        const componentMatches = fileData.match(/component\(/g);
+
+        if (controllerMatches) {
+            this.analysisDetails.controllersCount += controllerMatches.length;
             this.pushValueOnKey(this.analysisDetails.mapOfFilesToConvert, filename, " controller");
         }
-        if (fileData.match(/\.component\(/) || fileData.match(/component\(/)) {
-            this.analysisDetails.componentCount++;
+        if (componentMatches) {
+            this.analysisDetails.componentCount += componentMatches.length;
         }
     }
 


### PR DESCRIPTION
fix(analysisTool): Support more than 1 controller or component per file, which is a realistic scenario. For example, some apps may follow a modular structure similar to Angular where multiple controller/components are imported into the module declaration file where they are then registered with the module. Rather than simply incrementing the count, now add the number of matches found. Fixes #8.